### PR TITLE
Enable multiple audio items per year

### DIFF
--- a/src/components/DisplayScreen.jsx
+++ b/src/components/DisplayScreen.jsx
@@ -1,6 +1,7 @@
 // DisplayScreen.jsx
 import React, { useEffect } from 'react';
 import { useRadio } from '../context/RadioContext';
+import ItemNavigator from './ItemNavigator';
 import { animateScreen } from '../utils/audioUtils';
 
 export default function DisplayScreen() {
@@ -86,6 +87,7 @@ export default function DisplayScreen() {
             <br />
             <strong>Source:</strong><br />
             <a href={metadata?.url} target="_blank" rel="noopener noreferrer">{metadata?.url}</a>
+            <ItemNavigator />
           </div>
         )}
       </div>

--- a/src/components/ItemNavigator.jsx
+++ b/src/components/ItemNavigator.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useRadio } from '../context/RadioContext';
+
+export default function ItemNavigator() {
+  const { nextItem, prevItem, itemUids, itemIndex } = useRadio();
+
+  if (!itemUids || itemUids.length <= 1) return null;
+
+  return (
+    <div className="item-navigation">
+      <button onClick={prevItem} disabled={itemIndex === 0}>◀</button>
+      <span className="item-count">{itemIndex + 1} / {itemUids.length}</span>
+      <button onClick={nextItem} disabled={itemIndex === itemUids.length - 1}>▶</button>
+    </div>
+  );
+}

--- a/src/components/Radio.css
+++ b/src/components/Radio.css
@@ -298,6 +298,25 @@ button svg{
   filter: drop-shadow(0 0 2px #0008);
 }
 
+.item-navigation {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5em;
+  margin-top: 0.5rem;
+}
+
+.item-navigation button {
+  width: 2.5em;
+  height: 2.5em;
+  padding: 0;
+  font-size: 1.2em;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* Additional styling for loading, error, and now-playing text */
 .loading,
 .error,

--- a/src/services/AudioService.jsx
+++ b/src/services/AudioService.jsx
@@ -44,9 +44,10 @@ export async function fetchAudioByYear(year, encodedTitle = null) {
          (resource.url && (resource.url.includes('.mp3') || resource.url.includes('.wav')))
       )
     );
+    const itemUids = playableItems.map(item => extractUid(item.id)).filter(Boolean);
     
     if (playableItems.length === 0) {
-      const result = { audioUrl: null, metadata: null, title: null, error: 'No playable audio found for this year.' };
+      const result = { audioUrl: null, metadata: null, title: null, error: 'No playable audio found for this year.', itemUids: [] };
       audioCache[cacheKey] = result;
       return result;
     }
@@ -89,7 +90,7 @@ export async function fetchAudioByYear(year, encodedTitle = null) {
       }
     }
     if (!audioUrl) {
-      const result = { audioUrl: null, metadata: null, title: null, error: 'No audio URL available for this item.' };
+      const result = { audioUrl: null, metadata: null, title: null, error: 'No audio URL available for this item.', itemUids };
       audioCache[cacheKey] = result;
       return result;
     }
@@ -129,14 +130,15 @@ export async function fetchAudioByYear(year, encodedTitle = null) {
       audioUrl,
       metadata,
       title: encodedAudioTitle,
-      error: null
+      error: null,
+      itemUids
     };
 
     audioCache[cacheKey] = result;
     return result;
   } catch (error) {
     console.error('Error fetching audio:', error);
-    const result = { audioUrl: null, metadata: null, title: null, error: 'Error fetching audio. Try another year or title.' };
+    const result = { audioUrl: null, metadata: null, title: null, error: 'Error fetching audio. Try another year or title.', itemUids: [] };
     audioCache[cacheKey] = result;
     return result;
   }


### PR DESCRIPTION
## Summary
- include item navigation to switch audio items within a year
- add ItemNavigator UI component
- expose navigation functions in radio context
- save list of item IDs from search results
- style navigation buttons

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407d11768483259c7f70619089ef0d