### PR TITLE
Replace knobs with navigation

### DIFF
--- a/src/components/Radio.jsx
+++ b/src/components/Radio.jsx
@@ -15,8 +15,7 @@ import {
 } from '../services/AudioService';
 import { useAudioManager } from '../hooks/useAudioManager';
 import DisplayScreen from './DisplayScreen';
-import VolumeKnob from './VolumeKnob';
-import TuningKnob from './TuningKnob';
+import ItemNavigator from './ItemNavigator';
 import Button from './Button';
 import YearSelector from './YearSelector';
 import './Radio.css';
@@ -365,8 +364,7 @@ export default function Radio() {
           <DisplayScreen />
           <YearSelector />
           <div className="controls">
-            <VolumeKnob />
-            <TuningKnob />
+            <ItemNavigator />
             <Button />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove VolumeKnob and TuningKnob from the Radio component
- add ItemNavigator to the controls area

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685162c1aac483259f4557dc1054829f