### PR TITLE
Refine item navigation UI

### DIFF
--- a/src/components/DisplayScreen.jsx
+++ b/src/components/DisplayScreen.jsx
@@ -1,7 +1,6 @@
 // DisplayScreen.jsx
 import React, { useEffect } from 'react';
 import { useRadio } from '../context/RadioContext';
-import ItemNavigator from './ItemNavigator';
 import { animateScreen } from '../utils/audioUtils';
 
 export default function DisplayScreen() {
@@ -87,7 +86,6 @@ export default function DisplayScreen() {
             <br />
             <strong>Source:</strong><br />
             <a href={metadata?.url} target="_blank" rel="noopener noreferrer">{metadata?.url}</a>
-            <ItemNavigator />
           </div>
         )}
       </div>

--- a/src/components/ItemNavigator.jsx
+++ b/src/components/ItemNavigator.jsx
@@ -1,16 +1,43 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useRadio } from '../context/RadioContext';
+import { animateScreen } from '../utils/audioUtils';
 
 export default function ItemNavigator() {
-  const { nextItem, prevItem, itemUids, itemIndex } = useRadio();
+  const { nextItem, prevItem, itemUids, itemIndex, isOn } = useRadio();
+  const screenRef = useRef(null);
 
-  if (!itemUids || itemUids.length <= 1) return null;
+  useEffect(() => {
+    if (screenRef.current) {
+      animateScreen(screenRef, isOn);
+    }
+  }, [isOn]);
+
+  const countText =
+    isOn && itemUids && itemUids.length > 0
+      ? `${itemIndex + 1} / ${itemUids.length}`
+      : '';
 
   return (
     <div className="item-navigation">
-      <button onClick={prevItem} disabled={itemIndex === 0}>◀</button>
-      <span className="item-count">{itemIndex + 1} / {itemUids.length}</span>
-      <button onClick={nextItem} disabled={itemIndex === itemUids.length - 1}>▶</button>
+      <button
+        onClick={prevItem}
+        disabled={!itemUids || itemIndex === 0}
+        aria-label="Previous item"
+      >
+        ◀
+      </button>
+      <div className="item-screen">
+        <div className="screen" ref={screenRef}>
+          {countText}
+        </div>
+      </div>
+      <button
+        onClick={nextItem}
+        disabled={!itemUids || itemIndex === (itemUids.length - 1)}
+        aria-label="Next item"
+      >
+        ▶
+      </button>
     </div>
   );
 }

--- a/src/components/Radio.css
+++ b/src/components/Radio.css
@@ -307,11 +307,22 @@ button svg{
 }
 
 .item-navigation button {
-  width: 2.5em;
-  height: 2.5em;
+  width: 2em;
+  height: 3.5em;
   padding: 0;
   font-size: 1.2em;
-  border-radius: 50%;
+  border-radius: 0.25em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.item-screen {
+  background: linear-gradient(45deg, #101010, #000000);
+  box-shadow: inset 0 0 0.5em #000;
+  border-radius: 0.25em;
+  width: 5em;
+  height: 3.5em;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- keep ItemNavigator visible at all times
- show item count inside its own small screen
- style nav buttons rectangular and align with play button
- remove old ItemNavigator from DisplayScreen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68518d773cec832593ff918bd8e13bcc