### PR TITLE
Fix item navigator screen visibility

### DIFF
--- a/src/components/ItemNavigator.jsx
+++ b/src/components/ItemNavigator.jsx
@@ -6,11 +6,13 @@ export default function ItemNavigator() {
   const { nextItem, prevItem, itemUids, itemIndex, isOn } = useRadio();
   const screenRef = useRef(null);
 
+  // Always animate the item screen to an "on" state so the black
+  // background remains visible even when the radio is off.
   useEffect(() => {
     if (screenRef.current) {
-      animateScreen(screenRef, isOn);
+      animateScreen(screenRef, true);
     }
-  }, [isOn]);
+  }, []);
 
   const countText =
     isOn && itemUids && itemUids.length > 0


### PR DESCRIPTION
## Summary
- keep item navigation screen visible even when radio off

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851957bc4048325a215984f6cd55678