### PR TITLE
Clarify limited LOC fallback seed metadata

### DIFF
--- a/scripts/generate-archive-cache.mjs
+++ b/scripts/generate-archive-cache.mjs
@@ -33,10 +33,10 @@ const FALLBACK_SEED = {
   source: 'bootstrap-manifest',
   sourceMetadata: {
     generator: 'scripts/generate-archive-cache.mjs',
-    strategy: 'fallback-seed',
+    strategy: 'fallback-seed-limited',
     searchUrl: buildSearchUrl(1),
     itemUrlTemplate: `${BASE_URL}/item/{itemId}/?fo=json`,
-    notes: 'Static fallback seed used when the Library of Congress API is unavailable during generation.'
+    notes: 'Limited fallback seed used when the Library of Congress API path is blocked during generation; full LOC ingestion requires a more reliable source because this seed is too small to replace the catalog.'
   },
   catalog: {
     generatedAt: '2026-03-19T00:00:00.000Z',

--- a/src/data/archive-cache.json
+++ b/src/data/archive-cache.json
@@ -3,10 +3,10 @@
   "source": "bootstrap-manifest",
   "sourceMetadata": {
     "generator": "scripts/generate-archive-cache.mjs",
-    "strategy": "fallback-seed",
+    "strategy": "fallback-seed-limited",
     "searchUrl": "https://www.loc.gov/search/?q=sound+recording&fa=original-format%3Asound+recording%7Cdigitized&fo=json&c=100&sp=1",
     "itemUrlTemplate": "https://www.loc.gov/item/{itemId}/?fo=json",
-    "notes": "Static fallback seed used when the Library of Congress API is unavailable during generation."
+    "notes": "Limited fallback seed used when the Library of Congress API path is blocked during generation; full LOC ingestion requires a more reliable source because this seed is too small to replace the catalog."
   },
   "catalog": {
     "generatedAt": "2026-03-19T00:00:00.000Z",


### PR DESCRIPTION
### Motivation
- The generator and checked-in archive cache currently label a small static seed as a general `fallback-seed` for the Library of Congress, which can be misleading when the LOC API path is blocked and the bundled seed is too small to act as a catalog replacement.

### Description
- Rename `sourceMetadata.strategy` to `fallback-seed-limited` and update `sourceMetadata.notes` in both `scripts/generate-archive-cache.mjs` and `src/data/archive-cache.json` to explicitly state the seed is limited and that full LOC ingestion requires a more reliable source.

### Testing
- Verified `src/data/archive-cache.json` parses with `node -e "JSON.parse(require('node:fs').readFileSync('src/data/archive-cache.json','utf8'))"` (success) and ran unit tests with `npm test -- --runInBand` (10 test suites, 60 tests passed); validated docs dataset with `node scripts/validate-static-dataset.mjs --dir docs/data` (success) while `npm run validate:static-dataset` failed in this environment due to a missing `public/data` directory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd4a1dd7708325a82b450a04f0e91f)