### PR TITLE
ci: reuse checked-in LOC archive cache for static dataset builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "test": "jest",
     "generate:archive-cache": "node scripts/generate-archive-cache.mjs",
-    "generate:static-dataset": "npm run generate:archive-cache",
+    "generate:static-dataset": "node scripts/generate-static-dataset.mjs",
     "materialize:static-dataset": "node scripts/materialize-static-dataset.mjs --dir public/data",
     "materialize:docs-dataset": "node scripts/materialize-static-dataset.mjs --dir docs/data",
     "test:functional": "playwright test",

--- a/scripts/generate-static-dataset.mjs
+++ b/scripts/generate-static-dataset.mjs
@@ -1,0 +1,28 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertNoDatasetValidationErrors, validateArchiveCacheDataset } from '../shared/datasetValidation.mjs';
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ARCHIVE_CACHE_PATH = path.join(ROOT_DIR, 'src', 'data', 'archive-cache.json');
+
+async function main() {
+  const archiveCache = JSON.parse(await readFile(ARCHIVE_CACHE_PATH, 'utf8'));
+  assertNoDatasetValidationErrors(validateArchiveCacheDataset(archiveCache));
+
+  const catalogEntryCount = Array.isArray(archiveCache?.catalog?.entries)
+    ? archiveCache.catalog.entries.length
+    : Array.isArray(archiveCache?.availableYears)
+      ? archiveCache.availableYears.length
+      : 0;
+
+  console.log(
+    `Using checked-in archive cache snapshot from ${ARCHIVE_CACHE_PATH} (${catalogEntryCount} catalog years).`
+  );
+  console.log('Static dataset generation in CI now reuses the committed snapshot instead of crawling the live LOC API.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/workflow-migration-plan.md
+++ b/workflow-migration-plan.md
@@ -10,11 +10,11 @@ This migration needs to cover both GitHub Actions workflows that currently depen
 ## Sequence
 
 1. **Add static dataset entry points in `package.json`.**
-   - Introduce `generate:static-dataset` as the generation entry point.
+   - Introduce `generate:static-dataset` as the generation entry point that validates and reuses the checked-in `src/data/archive-cache.json` snapshot for CI/static builds instead of crawling LOC live.
    - Introduce `materialize:static-dataset` as the materialization entry point that writes `public/data/**` before `vite build` runs.
    - Keep `generate:archive-cache` in place as a compatibility shim until both workflows have moved.
 2. **Move the Pages deployment workflow first.**
-   - Update `.github/workflows/pages-build-deployment.yml` to call `generate:static-dataset` and `materialize:static-dataset` before `npm run build`.
+   - Update `.github/workflows/pages-build-deployment.yml` to call `generate:static-dataset` and `materialize:static-dataset` before `npm run build`. The generation step should stay offline-friendly by validating the committed cache snapshot rather than fetching LOC in CI.
    - Keep the upload path pointed at `docs/`, because `vite.config.js` still sets `build.outDir = 'docs'`.
    - Verify the built artifact contains `docs/data/**`, relying on Vite's default behavior of copying `public/**` into the configured output directory.
 3. **Migrate the cache refresh workflow next.**


### PR DESCRIPTION
### Motivation
- The site generator was crawling the Library of Congress API during CI/static builds and was vulnerable to 429 throttling, causing fragile builds. 
- Provide a practical, offline-friendly CI flow that does not depend on live LOC requests for normal Pages/static builds.

### Description
- Add `scripts/generate-static-dataset.mjs`, a lightweight generator that validates and reuses the checked-in `src/data/archive-cache.json` snapshot instead of crawling the LOC API. 
- Update `package.json` so `generate:static-dataset` runs the new offline validator script rather than aliasing `generate:archive-cache`. 
- Document the behavior in `workflow-migration-plan.md`, clarifying that CI should validate and reuse the committed cache snapshot and keep `generate:archive-cache` as the dedicated live-refresh path. 
- Leave the existing materialization/validation scripts (`materialize-static-dataset.mjs`, `validate-static-dataset.mjs`) unchanged and compatible with the new generation step.

### Testing
- Ran `npm run generate:static-dataset` which loaded and validated the checked-in `src/data/archive-cache.json` successfully. 
- Ran `npm run materialize:static-dataset` which materialized the dataset into `public/data` successfully. 
- Ran `npm run validate:static-dataset` which validated the generated JSON directories successfully. 
- Ran full `npm run build` (Vite build + materialize to `docs/data` + validation) which completed without errors and produced the `docs` build artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd5ca0ede48325bf11c363aca3d075)